### PR TITLE
ramips: mt7620: [UPSTREAM] fix USB frequency scaling

### DIFF
--- a/target/linux/ramips/patches-4.4/0080-MIPS-ralink-fix-USB-frequency-scaling.patch
+++ b/target/linux/ramips/patches-4.4/0080-MIPS-ralink-fix-USB-frequency-scaling.patch
@@ -1,0 +1,33 @@
+From ae28413b3b8901ea00af3571e1c90d0228976e16 Mon Sep 17 00:00:00 2001
+From: John Crispin <blogic@openwrt.org>
+Date: Mon, 4 Jan 2016 20:23:57 +0100
+Subject: [PATCH 80/81] MIPS: ralink: fix USB frequency scaling
+
+Commit 418d29c87061 ("MIPS: ralink: Unify SoC id handling") was not fully
+correct. The logic for the SoC check got inverted. We need to check if it
+is not a MT76x8.
+
+Signed-off-by: John Crispin <blogic@openwrt.org>
+Cc: linux-mips@linux-mips.org
+Patchwork: https://patchwork.linux-mips.org/patch/11992/
+Signed-off-by: Ralf Baechle <ralf@linux-mips.org>
+---
+ arch/mips/ralink/mt7620.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/mips/ralink/mt7620.c b/arch/mips/ralink/mt7620.c
+index dfb04fc..fc19932 100644
+--- a/arch/mips/ralink/mt7620.c
++++ b/arch/mips/ralink/mt7620.c
+@@ -439,7 +439,7 @@ void __init ralink_clk_init(void)
+ 	ralink_clk_add("10000c00.uartlite", periph_rate);
+ 	ralink_clk_add("10180000.wmac", xtal_rate);
+ 
+-	if (IS_ENABLED(CONFIG_USB) && is_mt76x8()) {
++	if (IS_ENABLED(CONFIG_USB) && !is_mt76x8()) {
+ 		/*
+ 		 * When the CPU goes into sleep mode, the BUS clock will be
+ 		 * too low for USB to function properly. Adjust the busses
+-- 
+2.1.4
+


### PR DESCRIPTION
The logic for the SoC check got inverted. We need to check if it's
not a MT76x8.

Signed-off-by: D. Andrei Măceș <dmaces@nd.edu>